### PR TITLE
Fix video layout responsiveness on Patient Resource Page

### DIFF
--- a/static/css/cirsx-f8a9d4.webflow.css
+++ b/static/css/cirsx-f8a9d4.webflow.css
@@ -409,15 +409,10 @@ blockquote {
 .container.content-grid {
   grid-column-gap: 21px;
   grid-row-gap: 21px;
-  flex-flow: row;
-  flex: 0 auto;
-  order: 0;
   grid-template-rows: auto auto;
   grid-template-columns: 1fr 1fr 1fr 1fr;
   grid-auto-columns: 1fr;
-  justify-content: space-around;
-  align-items: stretch;
-  display: flex;
+  display: grid;
 }
 
 .navbar-wrapper {
@@ -5640,6 +5635,10 @@ blockquote {
   .paragraph-24 {
     margin-bottom: 0;
   }
+
+  .container.content-grid {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 @media screen and (min-width: 1440px) {
@@ -6191,7 +6190,7 @@ blockquote {
     grid-column-gap: 21px;
     grid-row-gap: 21px;
     grid-template-rows: auto auto;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-auto-columns: 1fr;
     max-width: 1660px;
     display: grid;
@@ -6731,6 +6730,7 @@ blockquote {
   .container.content-grid {
     grid-column-gap: 10px;
     grid-row-gap: 10px;
+    grid-template-columns: 1fr 1fr;
     width: auto;
     max-width: none;
   }
@@ -8549,6 +8549,10 @@ blockquote {
     align-items: center;
     margin-left: 0;
   }
+
+  .container.content-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media screen and (max-width: 479px) {
@@ -8582,8 +8586,7 @@ blockquote {
   }
 
   .container.content-grid {
-    flex-flow: column;
-    display: flex;
+    grid-template-columns: 1fr;
   }
 
   .page-title {


### PR DESCRIPTION
Updated the content-grid CSS to properly display videos in a responsive grid:
- Desktop (>= 1920px): 4 columns
- Laptop (1440px - 1919px): 3 columns
- Tablet (768px - 1439px): 2 columns
- Mobile (<= 767px): 1 column

Changes:
- Fixed main .container.content-grid to use display: grid instead of display: flex
- Added proper grid-template-columns for all responsive breakpoints
- Removed conflicting flex properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)